### PR TITLE
Fix typo in the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const handleRoot  = request => response(
 
 const allRoutes = Assemble.routes([
   get('/', handleRoot),
-  get('/users' handlerUsers)
+  get('/users', handleUsers)
 ])
 
 MilleFeuille.create(allRoutes)


### PR DESCRIPTION
A typo is present in the example given in the README.md.
This PR simply fixes it.